### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Which resulted in an unnecessary large layer in the middle of our image that was
 
 `wharfie` lets us avoid the COPY step by being a simple httpd with built in compression tied to our build structure (think, nginx but with rigid layout and built in packaging)
 
-With the resulting Dockerfile becomming
+With the resulting Dockerfile becoming
 
 ```
 FROM registry.office/base:latest


### PR DESCRIPTION
@Ladbrokes, I've corrected a typographical error in the documentation of the [wharfie](https://github.com/Ladbrokes/wharfie) project. Specifically, I've changed becomming to becoming. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
